### PR TITLE
Upgrade Kryo to 2.16.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,10 @@
-(defproject cascading.kryo "0.3.2-SNAPSHOT"
+(defproject cascading.kryo "0.4.0-SNAPSHOT"
   :description "Kryo serialization for Cascading."
   :source-path "src/clj"
   :java-source-path "src/jvm"
   :javac-options {:debug "true" :fork "true"}
-  :repositories {"conjars" "http://conjars.org/repo/"}
-  :dependencies [[com.twitter/kryo "2.04"]]
+  :dependencies [[com.esotericsoftware.kryo/kryo "2.16"]]
   :dev-dependencies [[org.apache.hadoop/hadoop-core "0.20.2-dev"]
-                     [midje "1.3.1" :exclusions [org.clojure/clojure]]
-                     [clojure "1.2.1"]
-                     [lein-midje "1.0.8"]])
+                     [midje "1.4.0" :exclusions [org.clojure/clojure]]
+                     [clojure "1.4.0"]
+                     [lein-midje "1.0.9"]])


### PR DESCRIPTION
Bump this project's minor version to account for API differences in Kryo.
