### PR TITLE
Use Input and Output Streams directly

### DIFF
--- a/src/jvm/cascading/kryo/KryoDeserializer.java
+++ b/src/jvm/cascading/kryo/KryoDeserializer.java
@@ -4,7 +4,6 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import org.apache.hadoop.io.serializer.Deserializer;
 
-import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -14,9 +13,7 @@ public class KryoDeserializer implements Deserializer<Object> {
     private Kryo kryo;
     private final KryoSerialization kryoSerialization;
     private final Class<Object> klass;
-
-    private DataInputStream inputStream;
-    private Input input = null;
+    private Input input;
 
     public KryoDeserializer(KryoSerialization kryoSerialization, Class<Object> klass) {
         this.kryoSerialization =  kryoSerialization;
@@ -25,36 +22,20 @@ public class KryoDeserializer implements Deserializer<Object> {
 
     public void open(InputStream in) throws IOException {
         kryo = kryoSerialization.populatedKryo();
-
-        if( in instanceof DataInputStream)
-            inputStream = (DataInputStream) in;
-        else
-            inputStream = new DataInputStream( in );
+        input = new Input(in);
     }
 
     public Object deserialize(Object o) throws IOException {
-        int len = inputStream.readInt();
-        byte[] bytes = new byte[len];
-        inputStream.readFully( bytes );
-
-        if (input == null)
-            input = new Input(bytes);
-        else
-            input.setBuffer(bytes);
-
         return kryo.readObject(input, klass);
     }
 
     // TODO: Bump the kryo version, add a kryo.reset();
     public void close() throws IOException {
-        if( input != null )
-            input.close();
-
         try {
-            if( inputStream != null )
-                inputStream.close();
+            if( input != null )
+                input.close();
         } finally {
-            inputStream = null;
+            input = null;
         }
     }
 }

--- a/src/jvm/cascading/kryo/KryoDeserializer.java
+++ b/src/jvm/cascading/kryo/KryoDeserializer.java
@@ -11,22 +11,25 @@ import java.io.InputStream;
 /** User: sritchie Date: 12/1/11 Time: 3:15 PM */
 public class KryoDeserializer implements Deserializer<Object> {
 
-    private final Kryo kryo;
+    private Kryo kryo;
+    private final KryoSerialization kryoSerialization;
     private final Class<Object> klass;
 
     private DataInputStream inputStream;
     private Input input = null;
 
-    public KryoDeserializer(Kryo kryo, Class<Object> klass) {
-        this.kryo =  kryo;
+    public KryoDeserializer(KryoSerialization kryoSerialization, Class<Object> klass) {
+        this.kryoSerialization =  kryoSerialization;
         this.klass = klass;
     }
 
     public void open(InputStream in) throws IOException {
+        kryo = kryoSerialization.populatedKryo();
+
         if( in instanceof DataInputStream)
-            this.inputStream = (DataInputStream) in;
+            inputStream = (DataInputStream) in;
         else
-            this.inputStream = new DataInputStream( in );
+            inputStream = new DataInputStream( in );
     }
 
     public Object deserialize(Object o) throws IOException {
@@ -42,6 +45,7 @@ public class KryoDeserializer implements Deserializer<Object> {
         return kryo.readObject(input, klass);
     }
 
+    // TODO: Bump the kryo version, add a kryo.reset();
     public void close() throws IOException {
         if( input != null )
             input.close();

--- a/src/jvm/cascading/kryo/KryoFactory.java
+++ b/src/jvm/cascading/kryo/KryoFactory.java
@@ -64,7 +64,7 @@ public class KryoFactory {
                     return serializerClass.getConstructor(com.esotericsoftware.kryo.Kryo.class).newInstance(k);
                 } catch (NoSuchMethodException ex2) {
                     try {
-                        return serializerClass.getConstructor(Class.class).newInstance(k, superClass);
+                        return serializerClass.getConstructor(Class.class).newInstance(superClass);
                     } catch (NoSuchMethodException ex3) {
                         return serializerClass.newInstance();
                     }

--- a/src/jvm/cascading/kryo/KryoSerialization.java
+++ b/src/jvm/cascading/kryo/KryoSerialization.java
@@ -70,10 +70,10 @@ public class KryoSerialization extends Configured implements Serialization<Objec
     }
 
     public Serializer<Object> getSerializer(Class<Object> aClass) {
-        return new KryoSerializer(populatedKryo());
+        return new KryoSerializer(this);
     }
 
     public Deserializer<Object> getDeserializer(Class<Object> aClass) {
-        return new KryoDeserializer(populatedKryo(), aClass);
+        return new KryoDeserializer(this, aClass);
     }
 }

--- a/src/jvm/cascading/kryo/KryoSerializer.java
+++ b/src/jvm/cascading/kryo/KryoSerializer.java
@@ -4,27 +4,15 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Output;
 import org.apache.hadoop.io.serializer.Serializer;
 
-import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
 /** User: sritchie Date: 12/1/11 Time: 11:57 AM */
 public class KryoSerializer implements Serializer<Object> {
 
-    /**
-     * Initial capacity of the Kryo Output object.
-     */
-    private static final int INIT_CAPACITY = 2000;
-
-    /**
-     * Maximum capacity of the Kryo Output object.
-     */
-    private static final int FINAL_CAPACITY = 2000000000;
-
     private Kryo kryo;
     private final KryoSerialization kryoSerialization;
-    private final Output output = new Output(INIT_CAPACITY, FINAL_CAPACITY);
-    private DataOutputStream outputStream;
+    private Output output;
 
     public KryoSerializer(KryoSerialization kryoSerialization) {
         this.kryoSerialization =  kryoSerialization;
@@ -32,32 +20,24 @@ public class KryoSerializer implements Serializer<Object> {
 
     public void open(OutputStream out) throws IOException {
         kryo = kryoSerialization.populatedKryo();
-
-        if( out instanceof DataOutputStream )
-            outputStream = (DataOutputStream) out;
-        else
-            outputStream = new DataOutputStream(out);
+        output = new Output(out);
     }
 
     public void serialize(Object o) throws IOException {
-        output.clear();
         kryo.writeObject(output, o);
-        byte[] bytes = output.toBytes();
-
-        outputStream.writeInt(bytes.length);
-        outputStream.write(bytes);
+        output.flush();
     }
 
     // TODO: Bump the kryo version, add a kryo.reset();
     public void close() throws IOException {
         kryo = null;
-        output.close();
 
         try {
-            if( outputStream != null )
-                outputStream.close();
+            if( output != null ) {
+                output.close();
+            }
         } finally {
-            outputStream = null;
+            output = null;
         }
     }
 }

--- a/src/jvm/cascading/kryo/KryoSerializer.java
+++ b/src/jvm/cascading/kryo/KryoSerializer.java
@@ -21,19 +21,22 @@ public class KryoSerializer implements Serializer<Object> {
      */
     private static final int FINAL_CAPACITY = 2000000000;
 
-    private final Kryo kryo;
+    private Kryo kryo;
+    private final KryoSerialization kryoSerialization;
     private final Output output = new Output(INIT_CAPACITY, FINAL_CAPACITY);
     private DataOutputStream outputStream;
 
-    public KryoSerializer(Kryo kryo) {
-        this.kryo =  kryo;
+    public KryoSerializer(KryoSerialization kryoSerialization) {
+        this.kryoSerialization =  kryoSerialization;
     }
 
     public void open(OutputStream out) throws IOException {
+        kryo = kryoSerialization.populatedKryo();
+
         if( out instanceof DataOutputStream )
-            this.outputStream = (DataOutputStream) out;
+            outputStream = (DataOutputStream) out;
         else
-            this.outputStream = new DataOutputStream(out);
+            outputStream = new DataOutputStream(out);
     }
 
     public void serialize(Object o) throws IOException {
@@ -45,7 +48,9 @@ public class KryoSerializer implements Serializer<Object> {
         outputStream.write(bytes);
     }
 
+    // TODO: Bump the kryo version, add a kryo.reset();
     public void close() throws IOException {
+        kryo = null;
         output.close();
 
         try {


### PR DESCRIPTION
This pull req MIGHT fix the OOM issues we've been seeing in Cascading. The Output instance in KryoSerializer now wraps the stream, rather than holding some max capacity.
