### PR TITLE
KryoSerializer without intermediate buffer 

### DIFF
--- a/src/jvm/cascading/kryo/KryoDeserializer.java
+++ b/src/jvm/cascading/kryo/KryoDeserializer.java
@@ -10,40 +10,38 @@ import java.io.InputStream;
 
 public class KryoDeserializer implements Deserializer<Object> {
 
-    private java.io.DataInputStream is;
-    private Class<Object> klass;
-    private KryoSerialization ks;
-    private Kryo kryo;
+  private java.io.DataInputStream is;
+  private Class<Object> klass;
+  private KryoSerialization ks;
+  private Kryo kryo;
 
-    public KryoDeserializer(KryoSerialization kryoSerialization, Class<Object> klass) {
-      this.klass = klass;
-      ks = kryoSerialization;
-    }
+  public KryoDeserializer(KryoSerialization kryoSerialization, Class<Object> klass) {
+    this.klass = klass;
+    ks = kryoSerialization;
+  }
 
-    public void open(InputStream in) throws IOException {
-        is = (java.io.DataInputStream)in;
-        kryo = ks.populatedKryo();
-    }
+  public void open(InputStream in) throws IOException {
+    is = (DataInputStream)in;
+    kryo = ks.populatedKryo();
+  }
 
-    public Object deserialize(Object o) throws IOException {
-      System.out.println("about to deserialize a " + klass.getName());
-      int sz = is.readInt();
-      System.out.println("sz " + sz); 
-      byte[] b  = new byte[sz];
-      is.read(b);
-      //return(new java.io.ObjectInputStream(new java.io.ByteArrayInputStream(b))).readObject();
-      return(kryo.readObject(new Input(b), klass));
-    }
+  public Object deserialize(Object o) throws IOException {
+    int sz = is.readInt();
+    byte[] b  = new byte[sz];
+    is.read(b);
+    //return(new java.io.ObjectInputStream(new java.io.ByteArrayInputStream(b))).readObject();
+    return(kryo.readObject(new Input(b), klass));
+  }
 
-    // TODO: Bump the kryo version, add a kryo.reset();
-    public void close() throws IOException {
-        try {
-            if(is != null) is.close();
-        } catch(Exception e ) {
-          e.printStackTrace();
-        } finally {
-            is = null;
-            kryo = null;
-        }
+  // TODO: Bump the kryo version, add a kryo.reset();
+  public void close() throws IOException {
+    try {
+      if(is != null) is.close();
+    } catch(Exception e ) {
+      e.printStackTrace();
+    } finally {
+      is = null;
+      kryo = null;
     }
+  }
 }

--- a/src/jvm/cascading/kryo/KryoDeserializer.java
+++ b/src/jvm/cascading/kryo/KryoDeserializer.java
@@ -10,40 +10,40 @@ import java.io.InputStream;
 
 public class KryoDeserializer implements Deserializer<Object> {
 
+    private java.io.DataInputStream is;
+    private Class<Object> klass;
+    private KryoSerialization ks;
     private Kryo kryo;
-    private final KryoSerialization kryoSerialization;
-    private final Class<Object> klass;
-
-    private DataInputStream inputStream;
 
     public KryoDeserializer(KryoSerialization kryoSerialization, Class<Object> klass) {
-        this.kryoSerialization =  kryoSerialization;
-        this.klass = klass;
+      this.klass = klass;
+      ks = kryoSerialization;
     }
 
     public void open(InputStream in) throws IOException {
-        kryo = kryoSerialization.populatedKryo();
-
-        if( in instanceof DataInputStream)
-            inputStream = (DataInputStream) in;
-        else
-            inputStream = new DataInputStream( in );
+        is = (java.io.DataInputStream)in;
+        kryo = ks.populatedKryo();
     }
 
     public Object deserialize(Object o) throws IOException {
-        byte[] bytes = new byte[inputStream.readInt()];
-        inputStream.readFully( bytes );
-
-        return kryo.readObject(new Input(bytes), klass);
+      System.out.println("about to deserialize a " + klass.getName());
+      int sz = is.readInt();
+      System.out.println("sz " + sz); 
+      byte[] b  = new byte[sz];
+      is.read(b);
+      //return(new java.io.ObjectInputStream(new java.io.ByteArrayInputStream(b))).readObject();
+      return(kryo.readObject(new Input(b), klass));
     }
 
     // TODO: Bump the kryo version, add a kryo.reset();
     public void close() throws IOException {
         try {
-            if( inputStream != null )
-                inputStream.close();
+            if(is != null) is.close();
+        } catch(Exception e ) {
+          e.printStackTrace();
         } finally {
-            inputStream = null;
+            is = null;
+            kryo = null;
         }
     }
 }

--- a/src/jvm/cascading/kryo/KryoDeserializer.java
+++ b/src/jvm/cascading/kryo/KryoDeserializer.java
@@ -27,10 +27,14 @@ public class KryoDeserializer implements Deserializer<Object> {
 
   public Object deserialize(Object o) throws IOException {
     int sz = is.readInt();
+    System.out.println("deserialize " + klass.getName() + " size: " + sz);
     byte[] b  = new byte[sz];
     is.read(b);
-    //return(new java.io.ObjectInputStream(new java.io.ByteArrayInputStream(b))).readObject();
-    return(kryo.readObject(new Input(b), klass));
+    //Object ob = null; try { ob = new java.io.ObjectInputStream(new java.io.ByteArrayInputStream(b)).readObject(); } catch (ClassNotFoundException e){ }
+    Object ob = kryo.readObject(new Input(b), klass);
+    System.out.println("done deserializing");
+    return ob;
+    //return(kryo.readObject(new Input(b), klass));
   }
 
   // TODO: Bump the kryo version, add a kryo.reset();

--- a/src/jvm/cascading/kryo/KryoSerialization.java
+++ b/src/jvm/cascading/kryo/KryoSerialization.java
@@ -9,13 +9,6 @@ import org.apache.hadoop.io.serializer.Serializer;
 import org.objenesis.strategy.StdInstantiatorStrategy;
 
 public class KryoSerialization extends Configured implements Serialization<Object> {
-    public static final int OUTPUT_BUFFER_SIZE = 1<<12;
-    public static final int MAX_OUTPUT_BUFFER_SIZE = 1<<24;
-
-    public static final int TIDY_FACTOR = 1<<4;
-
-    public static final int SWITCH_LIMIT = Math.max(
-        KryoSerialization.MAX_OUTPUT_BUFFER_SIZE, KryoSerialization.MAX_OUTPUT_BUFFER_SIZE / TIDY_FACTOR);
 
     Kryo kryo;
     KryoFactory factory;

--- a/src/jvm/cascading/kryo/KryoSerializer.java
+++ b/src/jvm/cascading/kryo/KryoSerializer.java
@@ -4,65 +4,66 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Output;
 import org.apache.hadoop.io.serializer.Serializer;
 
-import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
 public class KryoSerializer implements Serializer<Object> {
+    private java.io.DataOutputStream os;
+    private KryoSerialization ks;
     private Kryo kryo;
-    private final KryoSerialization kryoSerialization;
-    private final Output output = new Output(
-        KryoSerialization.OUTPUT_BUFFER_SIZE, KryoSerialization.MAX_OUTPUT_BUFFER_SIZE);
-    private DataOutputStream outputStream;
-    private int prevPosition;
 
     public KryoSerializer(KryoSerialization kryoSerialization) {
-        this.kryoSerialization =  kryoSerialization;
+      ks = kryoSerialization;
     }
 
     public void open(OutputStream out) throws IOException {
-        kryo = kryoSerialization.populatedKryo();
-
-        if( out instanceof DataOutputStream)
-            outputStream = (DataOutputStream) out;
-        else
-            outputStream = new DataOutputStream(out);
-    }
-
-    // We tidy prevent output from maintaining a giant internal buffer.
-    public void tidyBuffer() {
-        int currentPosition = output.position();
-
-        // If the previous serialized object was large (greater than the switch size) and the current
-        // object falls below the switch size, reset the buffer to be small again. If both objects
-        // are small (or large), no reallocation occurs.
-        if (prevPosition > KryoSerialization.SWITCH_LIMIT && currentPosition <= KryoSerialization.SWITCH_LIMIT)
-            output.setBuffer(new byte[KryoSerialization.OUTPUT_BUFFER_SIZE], KryoSerialization.MAX_OUTPUT_BUFFER_SIZE);
-
-        prevPosition = currentPosition;
-        output.clear();
+        os = (java.io.DataOutputStream)out;
+        kryo = ks.populatedKryo();
     }
 
     public void serialize(Object o) throws IOException {
-        kryo.writeObject(output, o);
-        byte[] bytes = output.toBytes();
-
-        outputStream.writeInt(bytes.length);
-        outputStream.write(bytes);
-
-        tidyBuffer();
+      System.out.println("about to serialize a " + o.getClass().getName());
+      // get siez in bytes of serialized form.
+      FakeOutputStream fo = new FakeOutputStream();
+      //(new java.io.ObjectOutputStream(fo)).writeObject(o);
+      Output ko = new Output(fo);
+      kryo.writeObject(ko, o);
+      ko.flush();
+      int size = fo.size;
+      System.out.println("size " + size + " bytes");
+      java.io.ByteArrayOutputStream bho = new java.io.ByteArrayOutputStream(size);
+      //(new java.io.ObjectOutputStream(bho)).writeObject(o);
+      ko = new Output(bho);
+      kryo.writeObject(ko, o);
+      ko.flush();
+      os.writeInt(bho.size());
+      os.write(bho.toByteArray(), 0, bho.size());
+      os.flush();
     }
 
     // TODO: Bump the kryo version, add a kryo.reset();
     public void close() throws IOException {
-        kryo = null;
-
         try {
-            if( outputStream != null ) {
-                outputStream.close();
-            }
+            if(os != null)
+              os.close();
+        } catch(Exception e) {
+            e.printStackTrace();
         } finally {
-            outputStream = null;
+            os = null;
+            kryo = null;
         }
+    }
+
+    static class FakeOutputStream extends java.io.OutputStream {
+      int size = 0;
+      public void write(int b) {
+        size += 4;
+      }
+      public void write(byte[] b) {
+        size += b.length;
+      }
+      public void write(byte[] b, int off, int len) {
+        size += len;
+      }
     }
 }

--- a/src/jvm/cascading/kryo/KryoSerializer.java
+++ b/src/jvm/cascading/kryo/KryoSerializer.java
@@ -23,6 +23,7 @@ public class KryoSerializer implements Serializer<Object> {
   }
 
   public void serialize(Object o) throws IOException {
+    System.out.println("serialize" + o.getClass().getName());
     // get size in bytes of serialized form.
     FakeOutputStream fo = new FakeOutputStream();
     //(new java.io.ObjectOutputStream(fo)).writeObject(o);
@@ -38,6 +39,7 @@ public class KryoSerializer implements Serializer<Object> {
     os.writeInt(bho.size());
     os.write(bho.toByteArray(), 0, bho.size());
     os.flush();
+    System.out.println("done serialize, size " + size);
   }
 
   // TODO: Bump the kryo version, add a kryo.reset();

--- a/src/jvm/cascading/kryo/KryoSerializer.java
+++ b/src/jvm/cascading/kryo/KryoSerializer.java
@@ -13,6 +13,7 @@ public class KryoSerializer implements Serializer<Object> {
     private Kryo kryo;
     private final KryoSerialization kryoSerialization;
     private DataOutputStream outputStream;
+    private ByteArrayOutputStream byteStream;
 
     public KryoSerializer(KryoSerialization kryoSerialization) {
         this.kryoSerialization = kryoSerialization;
@@ -20,7 +21,7 @@ public class KryoSerializer implements Serializer<Object> {
 
     public void open(OutputStream out) throws IOException {
         kryo = kryoSerialization.populatedKryo();
-
+        byteStream = new ByteArrayOutputStream();
         if(out instanceof DataOutputStream)
             outputStream = (DataOutputStream)out;
         else
@@ -28,14 +29,15 @@ public class KryoSerializer implements Serializer<Object> {
     }
 
     public void serialize(Object o) throws IOException {
+        // Clear buffer.
+        byteStream.reset();
         // Write output to temorary buffer.
-        ByteArrayOutputStream bho = new ByteArrayOutputStream();
-        Output ko = new Output(bho);
+        Output ko = new Output(byteStream);
         kryo.writeObject(ko, o);
         ko.flush();
         // Copy from buffer to output stream.
-        outputStream.writeInt(bho.size());
-        outputStream.write(bho.toByteArray(), 0, bho.size());
+        outputStream.writeInt(byteStream.size());
+        byteStream.writeTo(outputStream);
         outputStream.flush();
     }
 
@@ -47,6 +49,7 @@ public class KryoSerializer implements Serializer<Object> {
         } finally {
             outputStream = null;
             kryo = null;
+            
         }
     }
 }

--- a/src/jvm/cascading/kryo/KryoSerializer.java
+++ b/src/jvm/cascading/kryo/KryoSerializer.java
@@ -5,11 +5,12 @@ import com.esotericsoftware.kryo.io.Output;
 import org.apache.hadoop.io.serializer.Serializer;
 
 import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
 public class KryoSerializer implements Serializer<Object> {
-  private java.io.DataOutputStream os;
+  private DataOutputStream os;
   private KryoSerialization ks;
   private Kryo kryo;
 
@@ -18,7 +19,10 @@ public class KryoSerializer implements Serializer<Object> {
   }
 
   public void open(OutputStream out) throws IOException {
-    os = (java.io.DataOutputStream)out;
+    if(out instanceof DataOutputStream)
+      os = (java.io.DataOutputStream)out;
+    else
+      os = new DataOutputStream(out);
     kryo = ks.populatedKryo();
   }
 

--- a/src/jvm/cascading/kryo/KryoSerializer.java
+++ b/src/jvm/cascading/kryo/KryoSerializer.java
@@ -43,8 +43,6 @@ public class KryoSerializer implements Serializer<Object> {
     try {
       if(os != null)
         os.close();
-    } catch(Exception e) {
-      e.printStackTrace();
     } finally {
       os = null;
       kryo = null;

--- a/src/jvm/cascading/kryo/KryoSerializer.java
+++ b/src/jvm/cascading/kryo/KryoSerializer.java
@@ -4,66 +4,65 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Output;
 import org.apache.hadoop.io.serializer.Serializer;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
 public class KryoSerializer implements Serializer<Object> {
-    private java.io.DataOutputStream os;
-    private KryoSerialization ks;
-    private Kryo kryo;
+  private java.io.DataOutputStream os;
+  private KryoSerialization ks;
+  private Kryo kryo;
 
-    public KryoSerializer(KryoSerialization kryoSerialization) {
-      ks = kryoSerialization;
-    }
+  public KryoSerializer(KryoSerialization kryoSerialization) {
+    ks = kryoSerialization;
+  }
 
-    public void open(OutputStream out) throws IOException {
-        os = (java.io.DataOutputStream)out;
-        kryo = ks.populatedKryo();
-    }
+  public void open(OutputStream out) throws IOException {
+    os = (java.io.DataOutputStream)out;
+    kryo = ks.populatedKryo();
+  }
 
-    public void serialize(Object o) throws IOException {
-      System.out.println("about to serialize a " + o.getClass().getName());
-      // get siez in bytes of serialized form.
-      FakeOutputStream fo = new FakeOutputStream();
-      //(new java.io.ObjectOutputStream(fo)).writeObject(o);
-      Output ko = new Output(fo);
-      kryo.writeObject(ko, o);
-      ko.flush();
-      int size = fo.size;
-      System.out.println("size " + size + " bytes");
-      java.io.ByteArrayOutputStream bho = new java.io.ByteArrayOutputStream(size);
-      //(new java.io.ObjectOutputStream(bho)).writeObject(o);
-      ko = new Output(bho);
-      kryo.writeObject(ko, o);
-      ko.flush();
-      os.writeInt(bho.size());
-      os.write(bho.toByteArray(), 0, bho.size());
-      os.flush();
-    }
+  public void serialize(Object o) throws IOException {
+    // get size in bytes of serialized form.
+    FakeOutputStream fo = new FakeOutputStream();
+    //(new java.io.ObjectOutputStream(fo)).writeObject(o);
+    Output ko = new Output(fo);
+    kryo.writeObject(ko, o);
+    ko.flush();
+    int size = fo.size;
+    ByteArrayOutputStream bho = new ByteArrayOutputStream(size);
+    //(new java.io.ObjectOutputStream(bho)).writeObject(o);
+    ko = new Output(bho);
+    kryo.writeObject(ko, o);
+    ko.flush();
+    os.writeInt(bho.size());
+    os.write(bho.toByteArray(), 0, bho.size());
+    os.flush();
+  }
 
-    // TODO: Bump the kryo version, add a kryo.reset();
-    public void close() throws IOException {
-        try {
-            if(os != null)
-              os.close();
-        } catch(Exception e) {
-            e.printStackTrace();
-        } finally {
-            os = null;
-            kryo = null;
-        }
+  // TODO: Bump the kryo version, add a kryo.reset();
+  public void close() throws IOException {
+    try {
+      if(os != null)
+        os.close();
+    } catch(Exception e) {
+      e.printStackTrace();
+    } finally {
+      os = null;
+      kryo = null;
     }
+  }
 
-    static class FakeOutputStream extends java.io.OutputStream {
-      int size = 0;
-      public void write(int b) {
-        size += 4;
-      }
-      public void write(byte[] b) {
-        size += b.length;
-      }
-      public void write(byte[] b, int off, int len) {
-        size += len;
-      }
+  static class FakeOutputStream extends OutputStream {
+    int size = 0;
+    public void write(int b) {
+      size += 4;
     }
+    public void write(byte[] b) {
+      size += b.length;
+    }
+    public void write(byte[] b, int off, int len) {
+      size += len;
+    }
+  }
 }

--- a/src/jvm/cascading/kryo/KryoSerializer.java
+++ b/src/jvm/cascading/kryo/KryoSerializer.java
@@ -44,12 +44,13 @@ public class KryoSerializer implements Serializer<Object> {
     // TODO: Bump the kryo version, add a kryo.reset();
     public void close() throws IOException {
         try {
-            if(outputStream != null)
+            if(outputStream != null) {
                 outputStream.close();
+            }
         } finally {
             outputStream = null;
+            byteStream = null;
             kryo = null;
-            
         }
     }
 }

--- a/src/jvm/cascading/kryo/KryoSerializer.java
+++ b/src/jvm/cascading/kryo/KryoSerializer.java
@@ -23,23 +23,15 @@ public class KryoSerializer implements Serializer<Object> {
   }
 
   public void serialize(Object o) throws IOException {
-    System.out.println("serialize" + o.getClass().getName());
-    // get size in bytes of serialized form.
-    FakeOutputStream fo = new FakeOutputStream();
-    //(new java.io.ObjectOutputStream(fo)).writeObject(o);
-    Output ko = new Output(fo);
+    // Write output to temorary buffer.
+    ByteArrayOutputStream bho = new ByteArrayOutputStream();
+    Output ko = new Output(bho);
     kryo.writeObject(ko, o);
     ko.flush();
-    int size = fo.size;
-    ByteArrayOutputStream bho = new ByteArrayOutputStream(size);
-    //(new java.io.ObjectOutputStream(bho)).writeObject(o);
-    ko = new Output(bho);
-    kryo.writeObject(ko, o);
-    ko.flush();
+    // Copy from buffer to output stream.
     os.writeInt(bho.size());
     os.write(bho.toByteArray(), 0, bho.size());
     os.flush();
-    System.out.println("done serialize, size " + size);
   }
 
   // TODO: Bump the kryo version, add a kryo.reset();
@@ -52,19 +44,6 @@ public class KryoSerializer implements Serializer<Object> {
     } finally {
       os = null;
       kryo = null;
-    }
-  }
-
-  static class FakeOutputStream extends OutputStream {
-    int size = 0;
-    public void write(int b) {
-      size += 4;
-    }
-    public void write(byte[] b) {
-      size += b.length;
-    }
-    public void write(byte[] b, int off, int len) {
-      size += len;
     }
   }
 }

--- a/src/jvm/cascading/kryo/KryoSerializer.java
+++ b/src/jvm/cascading/kryo/KryoSerializer.java
@@ -20,7 +20,7 @@ public class KryoSerializer implements Serializer<Object> {
 
   public void open(OutputStream out) throws IOException {
     if(out instanceof DataOutputStream)
-      os = (java.io.DataOutputStream)out;
+      os = (DataOutputStream)out;
     else
       os = new DataOutputStream(out);
     kryo = ks.populatedKryo();


### PR DESCRIPTION
this removes the intermediate buffer in the serializer, allowing the serialization of arbitrarily large objects, while maintaining the same format of the intermediate files.
